### PR TITLE
Update Shams Haroon company to Boardy

### DIFF
--- a/public/js/sites.js
+++ b/public/js/sites.js
@@ -1,7 +1,7 @@
 // Site data
 const sites = [
     { name: "Vincent Wong", url: "https://vinceklwong.com", year: 2027, recent_internship: "Shopify" },
-    { name: "Shams Haroon", url: "https://shamsharoon.com", year: 2028, recent_internship: "Wealthsimple" },
+    { name: "Shams Haroon", url: "https://shamsharoon.com", year: 2028, recent_internship: "Boardy" },
     { name: "Julian Cruzet", url: "https://juliancruzet.ca", year: 2027, recent_internship: "Shopify" },
     { name: "Jon McKesey", url: "https://jonathanmckesey.com/", year: 2027, recent_internship: "Verily" },
     { name: "Jun Bin Cheng", url: "https://jb-cheng.github.io/", year: 2026, recent_internship: "H.H Angus & Associates Ltd." },


### PR DESCRIPTION
## Summary
- Updated Shams Haroon's `recent_internship` from Wealthsimple to Boardy in the webring sites list

## Test plan
- [ ] Verify the webring displays "Boardy" for Shams Haroon's entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)