### PR TITLE
Add Matthew Serrano to webring

### DIFF
--- a/public/js/sites.js
+++ b/public/js/sites.js
@@ -11,7 +11,8 @@ const sites = [
     { name: "Ali Hakkani", url: "https://alihakkani.vercel.app/", year: 2027, recent_internship: "N/A" },
     { name: "DJ Leamen", url: "https://djleamen.ca", year: 2028, recent_internship: "Kyndryl" },
     { name: "Sunny Patel", url: "https://sunnypatel.net", year: 2027, recent_internship: "IBM" },
-    { name: "Chris Panetta", url: "https://chrispanetta.com", year: 2027, recent_internship: "Verkada" }
+    { name: "Chris Panetta", url: "https://chrispanetta.com", year: 2027, recent_internship: "Verkada" },
+    { name: "Matthew Serrano", url: "https://mattsrano.com", year: 2028, recent_internship: "OPS" }
 ];
 
 // YOU CAN ADD RECENT_INTERNSHIP OR GENERAL DESCRIPTION! (ex. Software Engineer, Full-Stack Developer, etc.)

--- a/public/js/sites.js
+++ b/public/js/sites.js
@@ -12,7 +12,7 @@ const sites = [
     { name: "DJ Leamen", url: "https://djleamen.ca", year: 2028, recent_internship: "Kyndryl" },
     { name: "Sunny Patel", url: "https://sunnypatel.net", year: 2027, recent_internship: "IBM" },
     { name: "Chris Panetta", url: "https://chrispanetta.com", year: 2027, recent_internship: "Verkada" },
-    { name: "Matthew Serrano", url: "https://mattsrano.com", year: 2028, recent_internship: "OPS" }
+    { name: "Matthew Serrano", url: "https://mattsrano.com", year: 2028, recent_internship: "Ontario Public Service" }
 ];
 
 // YOU CAN ADD RECENT_INTERNSHIP OR GENERAL DESCRIPTION! (ex. Software Engineer, Full-Stack Developer, etc.)


### PR DESCRIPTION
## Summary
- add Matthew Serrano to the `sites` array in `public/js/sites.js`
- include website, graduating year, and recent internship details

## Testing
- not run (data-only change)
